### PR TITLE
feat (timeout): Will now render timeout template or component

### DIFF
--- a/projects/loadable/src/lib/loadable.component.ts
+++ b/projects/loadable/src/lib/loadable.component.ts
@@ -93,11 +93,11 @@ export class LoadableComponent implements OnChanges {
     this.loadFn();
   }
 
-  _renderTimeoutTemplate() {
+  _renderTimeoutTemplateOrComponent() {
     this.timedOut = true;
     const module = this.ls.getModule(this.module);
     this.ls._renderVCR(
-      this.timeoutTemplate || (module && module.timeoutTemplate) || (this.options && this.options.timeoutTemplate),
+      this.timeoutTemplate || (module && module.timeoutComponent) || (this.options && this.options.timeoutComponent),
       this.content
     );
   }
@@ -114,10 +114,10 @@ export class LoadableComponent implements OnChanges {
     );
 
     if (this.timeout === 0) {
-      this._renderTimeoutTemplate();
+      this._renderTimeoutTemplateOrComponent();
     } else if (this.timeout > 0) {
       setTimeout(() => {
-        this._renderTimeoutTemplate();
+        this._renderTimeoutTemplateOrComponent();
       }, this.timeout);
     }
 

--- a/projects/loadable/src/lib/loadable.component.ts
+++ b/projects/loadable/src/lib/loadable.component.ts
@@ -93,7 +93,7 @@ export class LoadableComponent implements OnChanges {
     this.loadFn();
   }
 
-  _renderTimeoutTemplateOrComponent() {
+  _renderTimeout() {
     this.timedOut = true;
     const module = this.ls.getModule(this.module);
     this.ls._renderVCR(
@@ -114,10 +114,10 @@ export class LoadableComponent implements OnChanges {
     );
 
     if (this.timeout === 0) {
-      this._renderTimeoutTemplateOrComponent();
+      this._renderTimeout();
     } else if (this.timeout > 0) {
       setTimeout(() => {
-        this._renderTimeoutTemplateOrComponent();
+        this._renderTimeout();
       }, this.timeout);
     }
 

--- a/projects/loadable/src/lib/loadable.config.ts
+++ b/projects/loadable/src/lib/loadable.config.ts
@@ -7,7 +7,7 @@ export interface ModuleConfig {
   load: FunctionReturningPromise;
   loadingComponent?: Type<any>;
   errorComponent?: Type<any>;
-  timeoutTemplate?: Type<any>;
+  timeoutComponent?: Type<any>;
   timeout?: number;
   isElement?: boolean;
   preload?: boolean;
@@ -17,7 +17,7 @@ export interface ExtraOptions {
   timeout?: number;
   loadingComponent?: Type<any>;
   errorComponent?: Type<any>;
-  timeoutTemplate?: Type<any>;
+  timeoutComponent?: Type<any>;
   elements?: boolean;
 }
 
@@ -27,7 +27,7 @@ export interface ILoadableRootOptions {
   timeout?: number;
   loadingComponent?: Type<any>;
   errorComponent?: Type<any>;
-  timeoutTemplate?: Type<any>;
+  timeoutComponent?: Type<any>;
   isElement?: boolean;
   preload?: boolean;
 }


### PR DESCRIPTION
I simply change the name of `timeoutTemplate` to `timeoutComponent` as suggested (and a private method according to the semantic change). As far as I understand, this would work like with the `loadingComponent` out-of-the-box as the `_renderVCR` of `LoadingService` can render both templates and component. The type will still be the same `Type<any>`.

@mohammedzamakhan 
I have a couple of questions:
- I couldn't find a demo case for both LoadingComponent and some place where I can check the timeout component. Are there any or do we need to create one?
- Should I update any docs or changelogs alongside this PR?
- Is it correct that there is no inner functionality to be changed in order to make this work?

I had some trouble btw getting started with the packge.json. Can you reproduce any of these?
- tsc is only working when ts is installed globally
- cpy command is not working for me although it is installed via dependencies